### PR TITLE
small fixe to make the code works with YoloV2, an  expected string wa…

### DIFF
--- a/cfg/process.py
+++ b/cfg/process.py
@@ -286,7 +286,7 @@ def cfg_yielder(model, binary):
 		#-----------------------------------------------------
 		elif d['type'] == '[route]': # add new layer here
 			routes = d['layers']
-			if type(routes) is str:
+			if type(routes) is (unicode or str):
 				routes = [int(x.strip()) for x in routes.split(',')]
 			else: routes = [routes]
 			routes = [i + x if x < 0 else x for x in routes]


### PR DESCRIPTION
I tried to use the code with yolov2 from http://pjreddie.com/darknet/yolo/. It seems that the code didn't works because the list contained unicode and not string for the route layer. Fixed it simply by changing the condition for splitting the list value. Hope it does not break anything else.