### PR TITLE
don't hardcode directory for coco.names, use FLAGS.config instead

### DIFF
--- a/dark/darknet.py
+++ b/dark/darknet.py
@@ -47,7 +47,7 @@ class Darknet(object):
             '{} not found'.format(FLAGS.load)
             self.src_bin = FLAGS.load
             name = loader.model_name(FLAGS.load)
-            cfg_path = FLAGS.config+name+'.cfg'
+            cfg_path = os.path.join(FLAGS.config, name + '.cfg')
             if not os.path.isfile(cfg_path):
                 warnings.warn(
                     '{} not found, use {} instead'.format(

--- a/net/yolo/__init__.py
+++ b/net/yolo/__init__.py
@@ -17,7 +17,7 @@ def constructor(self, meta, FLAGS):
 		g = 2 - (indx % base2) % base
 		return (b * 127, r * 127, g * 127)
 
-	misc.labels(meta)
+	misc.labels(meta, FLAGS)
 	assert len(meta['labels']) == meta['classes'], (
 		'labels.txt and {} indicate' + ' '
 		'inconsistent class numbers'

--- a/net/yolo/misc.py
+++ b/net/yolo/misc.py
@@ -20,16 +20,16 @@ coco_models = ['tiny-coco', 'yolo-coco',  # <- v1.1
 coco_names = 'coco.names'
 nine_names = '9k.names'
 
-def labels(meta):    
+def labels(meta, FLAGS):    
     model = meta['name']
     if model in voc_models: 
         meta['labels'] = labels20
     else:
         file = 'labels.txt'
-        if model in coco_models: 
-            file = os.path.join('cfg', coco_names)
+        if model in coco_models:
+            file = os.path.join(FLAGS.config, coco_names)
         elif model == 'yolo9000':
-            file = os.path.join('cfg', nine_names)
+            file = os.path.join(FLAGS.config, nine_names)
         with open(file, 'r') as f:
             meta['labels'] = list()
             labs = [l.strip() for l in f.readlines()]


### PR DESCRIPTION
Hi! `coco.names` is in the `cfg/` directory alongside `yolo*.cfg`, so I think it makes sense to use FLAGS.config for both of them. This commit makes them both consistent, so users can set the directory path on the command line.

(Without this change, I can't import darkflow or run ./flow from a different directory.)