### PR TITLE
fix unicode issue while parsing route layer with more than one layer

### DIFF
--- a/cfg/process.py
+++ b/cfg/process.py
@@ -286,9 +286,7 @@ def cfg_yielder(model, binary):
 		#-----------------------------------------------------
 		elif d['type'] == '[route]': # add new layer here
 			routes = d['layers']
-			if type(routes) is str:
-				routes = [int(x.strip()) for x in routes.split(',')]
-			else: routes = [routes]
+			routes = [int(x.strip()) for x in str(routes).split(',')]
 			routes = [i + x if x < 0 else x for x in routes]
 			for j, x in enumerate(routes):
 				lx = layers[x]; xtype = lx['type']


### PR DESCRIPTION
The original code cannot handle the following layer:
```
[route]
layers=-1,-3
```
since `layers` is a Unicode string.

Alternative solution could be:
```
289  -			if type(routes) is str: 
289  +			if type(routes) in [str, unicode]: 
```