### PR TITLE
Easy use of darkflow as a dependency & Other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ All input images from default folder `test/` are flowed through the net and pred
 ```
 json output can be generated with descriptions of the pixel location of each bounding box and the pixel location. Each prediction is stored in the `test/out` folder by default. An example json array is shown below.
 ```bash
-# Forward all images in test/ using tiny yolo and json output.
+# Forward all images in test/ using tiny yolo and JSON output.
 ./flow --test test/ --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights --json
 ```
-json output:
+JSON output:
 ```json
-[{"label":"person","topleft":{"x":184,"y":101},"bottomright":{"x":274,"y":382}},
-{"label":"dog","topleft":{"x":71,"y":263},"bottomright":{"x":193,"y":353}},
-{"label":"horse","topleft":{"x":412,"y":109},"bottomright":{"x":592,"y":337}}]
+[{"label":"person","confidence":0.56,topleft":{"x":184,"y":101},"bottomright":{"x":274,"y":382}},
+{"label":"dog","confidence":0.32,"topleft":{"x":71,"y":263},"bottomright":{"x":193,"y":353}},
+{"label":"horse","confidence":0.76,"topleft":{"x":412,"y":109},"bottomright":{"x":592,"y":337}}]
 ```
  - label: self explanatory
+ - confidence: somewhere between 0 and 1 (how confident yolo is about that detection)
  - topleft: pixel coordinate of top left corner of box.
  - bottomright: pixel coordinate of bottom right corner of box.
 
@@ -134,9 +135,9 @@ During training, the script will occasionally save intermediate results into Ten
 ```
 
 ### Using darkflow from another python application
-Please note that `return_predict(img)` must take an `numpy.ndarray`. Your image must be loaded beforehand and passed to return_predict. Passing the file path won't work.
+Please note that `return_predict(img)` must take an `numpy.ndarray`. Your image must be loaded beforehand and passed to `return_predict(img)`. Passing the file path won't work.
 
-Result from `return_predict(img)` will be a list of each object detected with a list of each object's values in the format `[[left, right, top, bottom, label, labelIndex, probabilityOfDetection]]` with `left, right, top, bottom` corresponding to the sides of the bounding box in pixel values mapped to the input image.
+Result from `return_predict(img)` will be a list of dictionaries representing each detected object's values in the same format as the JSON output listed above.
 
 ```python
 from net.build import TFNet

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ During training, the script will occasionally save intermediate results into Ten
 
 ### Camera demo
 
+```python
+from net.build import TFNet
+import cv2
+
+options = {"model": "cfg/yolo.cfg", "load": "bin/yolo.weights", "threshold": 0.1}
+
+tfnet = TFNet(options)
+
+imgcv = cv2.imread("./test/test.jpg")
+result = tfnet.return_predict(imgcv)
+print(result)
+```
+
+### Using darkflow from another python application
+
 ```bash
 ./flow --model cfg/yolo-3c.cfg --load bin/yolo-3c.weights --demo camera
 ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ During training, the script will occasionally save intermediate results into Ten
 ```
 
 ### Using darkflow from another python application
-Please note that `return_predict(img)` must take an `numpy.ndarray`, your image must be loaded beforehand and passed to return_predict, passing the file path won't work.
+Please note that `return_predict(img)` must take an `numpy.ndarray`. Your image must be loaded beforehand and passed to return_predict. Passing the file path won't work.
+
+Result from `return_predict(img)` will be a list of each object detected with a list of each object's characteristics, e.g ``[[]]`
 
 ```python
 from net.build import TFNet

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ During training, the script will occasionally save intermediate results into Ten
 
 ### Camera demo
 
+```bash
+./flow --model cfg/yolo-3c.cfg --load bin/yolo-3c.weights --demo camera
+```
+
+### Using darkflow from another python application
+
 ```python
 from net.build import TFNet
 import cv2
@@ -140,12 +146,6 @@ tfnet = TFNet(options)
 imgcv = cv2.imread("./test/test.jpg")
 result = tfnet.return_predict(imgcv)
 print(result)
-```
-
-### Using darkflow from another python application
-
-```bash
-./flow --model cfg/yolo-3c.cfg --load bin/yolo-3c.weights --demo camera
 ```
 
 ### Migrating the graph to mobile devices (JAVA / C++ / Objective-C++)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ During training, the script will occasionally save intermediate results into Ten
 ### Using darkflow from another python application
 Please note that `return_predict(img)` must take an `numpy.ndarray`. Your image must be loaded beforehand and passed to return_predict. Passing the file path won't work.
 
-Result from `return_predict(img)` will be a list of each object detected with a list of each object's characteristics, e.g ``[[]]`
+Result from `return_predict(img)` will be a list of each object detected with a list of each object's values in the format `[[left, right, top, bottom, label, labelIndex, probabilityOfDetection]]` with `left, right, top, bottom` corresponding to the sides of the bounding box in pixel values mapped to the input image.
 
 ```python
 from net.build import TFNet

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ During training, the script will occasionally save intermediate results into Ten
 ```
 
 ### Using darkflow from another python application
+Please note that `return_predict(img)` must take an `numpy.ndarray`, your image must be loaded beforehand and passed to return_predict, passing the file path won't work.
 
 ```python
 from net.build import TFNet

--- a/net/build.py
+++ b/net/build.py
@@ -7,6 +7,12 @@ from .ops import HEADER, LINE
 from .framework import create_framework
 from dark.darknet import Darknet
 
+class dotdict(dict):
+	"""dot.notation access to dictionary attributes to replace FLAGS when not needed"""
+	__getattr__ = dict.get
+	__setattr__ = dict.__setitem__
+	__delattr__ = dict.__delitem__
+
 class TFNet(object):
 
 	_TRAINER = dict({
@@ -24,12 +30,18 @@ class TFNet(object):
 	train = flow.train
 	camera = help.camera
 	predict = flow.predict
+	return_predict = flow.return_predict
 	to_darknet = help.to_darknet
 	build_train_op = help.build_train_op
 	load_from_ckpt = help.load_from_ckpt
 
 	def __init__(self, FLAGS, darknet = None):
 		self.ntrain = 0
+		if isinstance(FLAGS, dict):
+			defaultSettings = {"binary": "./bin/", "config": "./cfg/", "batch": 16, "threshold": 0.1, "train": False, "verbalise": False, "gpu": 0.0}
+			defaultSettings.update(FLAGS)
+			FLAGS = dotdict(defaultSettings)
+
 		if darknet is None:	
 			darknet = Darknet(FLAGS)
 			self.ntrain = len(darknet.layers)

--- a/net/flow.py
+++ b/net/flow.py
@@ -67,20 +67,20 @@ def train(self):
 def return_predict(self, im):
     assert isinstance(im, np.ndarray), \
 				'Image is not a np.ndarray'
+    h, w, _ = im.shape
     im = self.framework.resize_input(im)
     this_inp = np.expand_dims(im, 0)
     feed_dict = {self.inp : this_inp}
 
-    out = self.sess.run(self.out, feed_dict)
+    out = self.sess.run(self.out, feed_dict)[0]
     boxes = self.framework.findboxes(out)
-    h, w, _ = im.shape
-    threshold = self.meta['thresh']
+    threshold = self.FLAGS.threshold
     boxesInfo = list()
     for box in boxes:
         tmpBox = self.framework.process_box(box, h, w, threshold)
         if tmpBox is None:
             continue
-        boxesInfo.append(tmpBox)
+        boxesInfo.append({"label":tmpBox[4],"confidence":tmpBox[6],"topleft":{"x":tmpBox[0],"y":tmpBox[2]},"bottomright":{"x":tmpBox[1],"y":tmpBox[3]}})
     return boxesInfo
 
 def predict(self):

--- a/net/flow.py
+++ b/net/flow.py
@@ -64,6 +64,22 @@ def train(self):
 
     if ckpt: _save_ckpt(self, *args)
 
+def return_predict(self, im):
+    im = self.framework.resize_input(im)
+    this_inp = np.expand_dims(im, 0)
+    feed_dict = {self.inp : this_inp}
+
+    out = self.sess.run(self.out, feed_dict)
+    boxes = self.framework.findboxes(out)
+    h, w, _ = im.shape
+    threshold = self.meta['thresh']
+    boxesInfo = list()
+    for box in boxes:
+        tmpBox = self.framework.process_box(box, h, w, threshold)
+        if tmpBox is None:
+            continue
+        boxesInfo.append(tmpBox)
+    return boxesInfo
 
 def predict(self):
     inp_path = self.FLAGS.test

--- a/net/flow.py
+++ b/net/flow.py
@@ -65,6 +65,8 @@ def train(self):
     if ckpt: _save_ckpt(self, *args)
 
 def return_predict(self, im):
+    assert isinstance(im, np.ndarray), \
+				'Image is not a np.ndarray'
     im = self.framework.resize_input(im)
     this_inp = np.expand_dims(im, 0)
     feed_dict = {self.inp : this_inp}

--- a/net/framework.py
+++ b/net/framework.py
@@ -27,6 +27,9 @@ class YOLO(framework):
     is_inp = yolo.misc.is_inp
     profile = yolo.misc.profile
     _batch = yolo.data._batch
+    resize_input = yolo.test.resize_input
+    findboxes = yolo.test.findboxes
+    process_box = yolo.test.process_box
 
 class YOLOv2(framework):
     constructor = yolo.constructor
@@ -37,6 +40,9 @@ class YOLOv2(framework):
     is_inp = yolo.misc.is_inp
     postprocess = yolov2.test.postprocess
     _batch = yolov2.data._batch
+    resize_input = yolo.test.resize_input
+    findboxes = yolov2.test.findboxes
+    process_box = yolo.test.process_box
 
 """
 framework factory

--- a/net/ops/simple.py
+++ b/net/ops/simple.py
@@ -14,10 +14,7 @@ class route(BaseOp):
 				assert this is not None, \
 				'Routing to non-existence {}'.format(r)
 			routes_out += [this.out]
-		if(StrictVersion(tf.__version__) >= StrictVersion('0.12.0')):
-			self.out = tf.concat(3, routes_out)
-		else:
-			self.out = tf.concat(routes_out, 3) #Eventually remove this code once TensorFlow 1.0.0 is required by default (this is to support older versions)
+		self.out = tf.concat(routes_out, 3)
 
 	def speak(self):
 		msg = 'concat {}'

--- a/net/ops/simple.py
+++ b/net/ops/simple.py
@@ -1,6 +1,7 @@
 import tensorflow.contrib.slim as slim
 from .baseop import BaseOp
 import tensorflow as tf
+from distutils.version import StrictVersion
 
 class route(BaseOp):
 	def forward(self):
@@ -12,8 +13,11 @@ class route(BaseOp):
 				this = this.inp
 				assert this is not None, \
 				'Routing to non-existence {}'.format(r)
-			routes_out += [this.out]	
-		self.out = tf.concat(routes_out, 3)
+			routes_out += [this.out]
+		if(StrictVersion(tf.__version__) >= StrictVersion('1.0.0')):
+			self.out = tf.concat(3, routes_out)
+		else:
+			self.out = tf.concat(routes_out, 3) #Eventually remove this code once TensorFlow 1.0.0 is required by default (this is to support older versions)
 
 	def speak(self):
 		msg = 'concat {}'

--- a/net/ops/simple.py
+++ b/net/ops/simple.py
@@ -14,7 +14,7 @@ class route(BaseOp):
 				assert this is not None, \
 				'Routing to non-existence {}'.format(r)
 			routes_out += [this.out]
-		if(StrictVersion(tf.__version__) >= StrictVersion('1.0.0')):
+		if(StrictVersion(tf.__version__) >= StrictVersion('0.12.0')):
 			self.out = tf.concat(3, routes_out)
 		else:
 			self.out = tf.concat(routes_out, 3) #Eventually remove this code once TensorFlow 1.0.0 is required by default (this is to support older versions)

--- a/net/yolo/misc.py
+++ b/net/yolo/misc.py
@@ -21,7 +21,7 @@ coco_names = 'coco.names'
 nine_names = '9k.names'
 
 def labels(meta, FLAGS):    
-    model = meta['name']
+    model = meta['name'].split('/', 1)[-1]
     if model in voc_models: 
         meta['labels'] = labels20
     else:

--- a/net/yolo/test.py
+++ b/net/yolo/test.py
@@ -11,45 +11,34 @@ def _fix(obj, dims, scale, offs):
 		obj[i] = int(obj[i] * scale - off)
 		obj[i] = max(min(obj[i], dim), 0)
 
-def preprocess(self, im, allobj = None):
-	"""
-	Takes an image, return it as a numpy tensor that is readily
-	to be fed into tfnet. If there is an accompanied annotation (allobj),
-	meaning this preprocessing is serving the train process, then this
-	image will be transformed with random noise to augment training data,
-	using scale, translation, flipping and recolor. The accompanied
-	parsed annotation (allobj) will also be modified accordingly.
-	"""
-	if type(im) is not np.ndarray:
-		im = cv2.imread(im)
-
-	if allobj is not None: # in training mode
-		result = imcv2_affine_trans(im)
-		im, dims, trans_param = result
-		scale, offs, flip = trans_param
-		for obj in allobj:
-			_fix(obj, dims, scale, offs)
-			if not flip: continue
-			obj_1_ =  obj[1]
-			obj[1] = dims[0] - obj[3]
-			obj[3] = dims[0] - obj_1_
-		im = imcv2_recolor(im)
-
+def resize_input(self, im):
 	h, w, c = self.meta['inp_size']
 	imsz = cv2.resize(im, (h, w))
 	imsz = imsz / 255.
 	imsz = imsz[:,:,::-1]
-	if allobj is None: return imsz
-	return imsz#, np.array(im) # for unit testing
+	return imsz
 
-def postprocess(self, net_out, im, save = True):
-	"""
-	Takes net output, draw predictions, save to disk
-	"""
+def process_box(self, b, h, w, threshold):
+	max_indx = np.argmax(b.probs)
+	max_prob = b.probs[max_indx]
+	label = self.meta['labels'][max_indx]
+	if max_prob > threshold:
+		left  = int ((b.x - b.w/2.) * w)
+		right = int ((b.x + b.w/2.) * w)
+		top   = int ((b.y - b.h/2.) * h)
+		bot   = int ((b.y + b.h/2.) * h)
+		if left  < 0    :  left = 0
+		if right > w - 1: right = w - 1
+		if top   < 0    :   top = 0
+		if bot   > h - 1:   bot = h - 1
+		mess = '{}'.format(label)
+		return (left, right, top, bot, mess, max_indx, max_prob)
+	return None
+
+def findboxes(self, net_out):
 	meta, FLAGS = self.meta, self.FLAGS
 	threshold, sqrt = FLAGS.threshold, meta['sqrt'] + 1
 	C, B, S = meta['classes'], meta['num'], meta['side']
-	colors, labels = meta['colors'], meta['labels']
 
 	boxes = []
 	SS        =  S * S # number of grid cells
@@ -75,18 +64,46 @@ def postprocess(self, net_out, im, save = True):
 			p *= (p > threshold)
 			bx.probs = p
 			boxes.append(bx)
+	
+	return boxes
 
-	# non max suppress boxes
-	for c in range(C):
-		for i in range(len(boxes)): boxes[i].class_num = c
-		boxes = sorted(boxes, key = prob_compare, reverse = True)
-		for i in range(len(boxes)):
-			boxi = boxes[i]
-			if boxi.probs[c] == 0: continue
-			for j in range(i + 1, len(boxes)):
-				boxj = boxes[j]
-				if box_iou(boxi, boxj) >= .4:
-						boxes[j].probs[c] = 0.
+def preprocess(self, im, allobj = None):
+	"""
+	Takes an image, return it as a numpy tensor that is readily
+	to be fed into tfnet. If there is an accompanied annotation (allobj),
+	meaning this preprocessing is serving the train process, then this
+	image will be transformed with random noise to augment training data,
+	using scale, translation, flipping and recolor. The accompanied
+	parsed annotation (allobj) will also be modified accordingly.
+	"""
+	if type(im) is not np.ndarray:
+		im = cv2.imread(im)
+
+	if allobj is not None: # in training mode
+		result = imcv2_affine_trans(im)
+		im, dims, trans_param = result
+		scale, offs, flip = trans_param
+		for obj in allobj:
+			_fix(obj, dims, scale, offs)
+			if not flip: continue
+			obj_1_ =  obj[1]
+			obj[1] = dims[0] - obj[3]
+			obj[3] = dims[0] - obj_1_
+		im = imcv2_recolor(im)
+
+	im = self.resize_input(im)
+	if allobj is None: return im
+	return im#, np.array(im) # for unit testing
+
+def postprocess(self, net_out, im, save = True):
+	"""
+	Takes net output, draw predictions, save to disk
+	"""
+	meta, FLAGS = self.meta, self.FLAGS
+	threshold = FLAGS.threshold
+	colors, labels = meta['colors'], meta['labels']
+
+	boxes = self.findboxes(net_out)
 
 	if type(im) is not np.ndarray:
 		imgcv = cv2.imread(im)
@@ -94,35 +111,26 @@ def postprocess(self, net_out, im, save = True):
 	h, w, _ = imgcv.shape
 	textBuff = "["
 	for b in boxes:
-		max_indx = np.argmax(b.probs)
-		max_prob = b.probs[max_indx]
-		label = self.meta['labels'][max_indx]
-		if max_prob > threshold:
-			left  = int ((b.x - b.w/2.) * w)
-			right = int ((b.x + b.w/2.) * w)
-			top   = int ((b.y - b.h/2.) * h)
-			bot   = int ((b.y + b.h/2.) * h)
-			if left  < 0    :  left = 0
-			if right > w - 1: right = w - 1
-			if top   < 0    :   top = 0
-			if bot   > h - 1:   bot = h - 1
-			thick = int((h + w) // 300)
-			mess = '{}'.format(label)
-			if self.FLAGS.json:
-				line = 	('{"label":"%s",'
-						'"topleft":{"x":%d,"y":%d},'
-						'"bottomright":{"x":%d,"y":%d}},\n') % \
-						(mess, left, top, right, bot)
-				textBuff += line
-				continue
+		boxResults = self.process_box(b, h, w, threshold)
+		if boxResults is None:
+			continue
+		left, right, top, bot, mess, max_indx, _ = boxResults
+		thick = int((h + w) // 300)
+		if self.FLAGS.json:
+			line = 	('{"label":"%s",'
+					'"topleft":{"x":%d,"y":%d},'
+					'"bottomright":{"x":%d,"y":%d}},\n') % \
+					(mess, left, top, right, bot)
+			textBuff += line
+			continue
 
-			cv2.rectangle(imgcv,
-				(left, top), (right, bot),
-				self.meta['colors'][max_indx], thick)
-			cv2.putText(
-				imgcv, mess, (left, top - 12),
-				0, 1e-3 * h, self.meta['colors'][max_indx],
-				thick // 3)
+		cv2.rectangle(imgcv,
+			(left, top), (right, bot),
+			self.meta['colors'][max_indx], thick)
+		cv2.putText(
+			imgcv, mess, (left, top - 12),
+			0, 1e-3 * h, self.meta['colors'][max_indx],
+			thick // 3)
 
 	# Removing trailing comma+newline adding json list terminator.
 	textBuff = textBuff[:-2] + "]"

--- a/net/yolo/test.py
+++ b/net/yolo/test.py
@@ -114,13 +114,14 @@ def postprocess(self, net_out, im, save = True):
 		boxResults = self.process_box(b, h, w, threshold)
 		if boxResults is None:
 			continue
-		left, right, top, bot, mess, max_indx, _ = boxResults
+		left, right, top, bot, mess, max_indx, confidence = boxResults
 		thick = int((h + w) // 300)
 		if self.FLAGS.json:
 			line = 	('{"label":"%s",'
+					'"confidence":%.2f,'
 					'"topleft":{"x":%d,"y":%d},'
 					'"bottomright":{"x":%d,"y":%d}},\n') % \
-					(mess, left, top, right, bot)
+					(mess, confidence, left, top, right, bot)
 			textBuff += line
 			continue
 
@@ -132,15 +133,16 @@ def postprocess(self, net_out, im, save = True):
 			0, 1e-3 * h, self.meta['colors'][max_indx],
 			thick // 3)
 
+
+	if not save: return imgcv
 	# Removing trailing comma+newline adding json list terminator.
 	textBuff = textBuff[:-2] + "]"
+	outfolder = os.path.join(self.FLAGS.test, 'out')
+	img_name = os.path.join(outfolder, im.split('/')[-1])
 	if self.FLAGS.json:
 		textFile = os.path.splitext(img_name)[0] + ".json"
 		with open(textFile, 'w') as f:
 			f.write(textBuff)
 		return	
 
-	if not save: return imgcv
-	outfolder = os.path.join(self.FLAGS.test, 'out')
-	img_name = os.path.join(outfolder, im.split('/')[-1])
 	cv2.imwrite(img_name, imgcv)

--- a/net/yolov2/test.py
+++ b/net/yolov2/test.py
@@ -15,10 +15,7 @@ def _softmax(x):
     out = e_x / e_x.sum()
     return out
 
-def postprocess(self, net_out, im, save = True):
-	"""
-	Takes net output, draw net_out, save to disk
-	"""
+def findboxes(self, net_out):
 	# meta
 	meta = self.meta
 	H, W, _ = meta['out_size']
@@ -47,7 +44,7 @@ def postprocess(self, net_out, im, save = True):
 	for c in range(C):
 		for i in range(len(boxes)):
 			boxes[i].class_num = c
-		boxes = sorted(boxes, key = prob_compare, reverse = True)
+		boxes = sorted(boxes, key=prob_compare, reverse=True)
 		for i in range(len(boxes)):
 			boxi = boxes[i]
 			if boxi.probs[c] == 0: continue
@@ -55,8 +52,17 @@ def postprocess(self, net_out, im, save = True):
 				boxj = boxes[j]
 				if box_iou(boxi, boxj) >= .4:
 					boxes[j].probs[c] = 0.
+	return boxes
 
+def postprocess(self, net_out, im, save = True):
+	"""
+	Takes net output, draw net_out, save to disk
+	"""
+	boxes = self.findboxes(net_out)
 
+	# meta
+	meta = self.meta
+	threshold = meta['thresh']
 	colors = meta['colors']
 	labels = meta['labels']
 	if type(im) is not np.ndarray:
@@ -66,33 +72,24 @@ def postprocess(self, net_out, im, save = True):
 	
 	textBuff = "["
 	for b in boxes:
-		max_indx = np.argmax(b.probs)
-		max_prob = b.probs[max_indx]
-		label = labels[max_indx]
-		if max_prob > threshold:
-			left  = int ((b.x - b.w/2.) * w)
-			right = int ((b.x + b.w/2.) * w)
-			top   = int ((b.y - b.h/2.) * h)
-			bot   = int ((b.y + b.h/2.) * h)
-			if left  < 0    :  left = 0
-			if right > w - 1: right = w - 1
-			if top   < 0    :   top = 0
-			if bot   > h - 1:   bot = h - 1
-			thick = int((h+w)/300)
-			mess = '{}'.format(label)
-			if self.FLAGS.json:
-				line = 	('{"label":"%s",'
-						'"topleft":{"x":%d,"y":%d},'
-						'"bottomright":{"x":%d,"y":%d}},\n') % \
-						(mess, left, top, right, bot)
-				textBuff += line
-				continue
+		boxResults = self.process_box(b, h, w, threshold)
+		if boxResults is None:
+			continue
+		left, right, top, bot, mess, max_indx, _ = boxResults
+		thick = int((h + w) // 300)
+		if self.FLAGS.json:
+			line = 	('{"label":"%s",'
+					'"topleft":{"x":%d,"y":%d},'
+					'"bottomright":{"x":%d,"y":%d}},\n') % \
+					(mess, left, top, right, bot)
+			textBuff += line
+			continue
 
-			cv2.rectangle(imgcv,
-				(left, top), (right, bot),
-				colors[max_indx], thick)
-			cv2.putText(imgcv, mess, (left, top - 12),
-				0, 1e-3 * h, colors[max_indx],thick//3)
+		cv2.rectangle(imgcv,
+			(left, top), (right, bot),
+			colors[max_indx], thick)
+		cv2.putText(imgcv, mess, (left, top - 12),
+			0, 1e-3 * h, colors[max_indx],thick//3)
 
 	# Removing trailing comma+newline adding json list terminator.
 	textBuff = textBuff[:-2] + "]"

--- a/net/yolov2/test.py
+++ b/net/yolov2/test.py
@@ -75,13 +75,14 @@ def postprocess(self, net_out, im, save = True):
 		boxResults = self.process_box(b, h, w, threshold)
 		if boxResults is None:
 			continue
-		left, right, top, bot, mess, max_indx, _ = boxResults
+		left, right, top, bot, mess, max_indx, confidence = boxResults
 		thick = int((h + w) // 300)
 		if self.FLAGS.json:
 			line = 	('{"label":"%s",'
+					'"confidence":%.2f,'
 					'"topleft":{"x":%d,"y":%d},'
 					'"bottomright":{"x":%d,"y":%d}},\n') % \
-					(mess, left, top, right, bot)
+					(mess, confidence, left, top, right, bot)
 			textBuff += line
 			continue
 
@@ -91,15 +92,15 @@ def postprocess(self, net_out, im, save = True):
 		cv2.putText(imgcv, mess, (left, top - 12),
 			0, 1e-3 * h, colors[max_indx],thick//3)
 
+	if not save: return imgcv
 	# Removing trailing comma+newline adding json list terminator.
 	textBuff = textBuff[:-2] + "]"
+	outfolder = os.path.join(self.FLAGS.test, 'out')
+	img_name = os.path.join(outfolder, im.split('/')[-1])
 	if self.FLAGS.json:
 		textFile = os.path.splitext(img_name)[0] + ".json"
 		with open(textFile, 'w') as f:
 			f.write(textBuff)
 		return
 
-	if not save: return imgcv
-	outfolder = os.path.join(self.FLAGS.test, 'out')
-	img_name = os.path.join(outfolder, im.split('/')[-1])
 	cv2.imwrite(img_name, imgcv)


### PR DESCRIPTION
1. I've done a little code consolidation (a little bit of duplicated code between YOLO v1 and YOLO v2 test files) and reorganized the code a little so as to allow for programmic interaction with darkflow (initializing the nets and then passing loaded images to be processed and having the results easily returned).

2. In `./net/yolo/misc.py`,  `model = meta['name']` was setting `model` to the relative file path and the file name and extention, not just the name and extention resulting in the subsequent comparisons to determine the proper label file failing. I changed this to `model = meta['name'].split('/', 1)[-1]` which extracts the actual file name and extention and the comparison completes proplerly. I don't totally understand how something like this has gone unnoticed - so maybe I'm missing something?

~3. In newer versions of TensorFlow, tf.concat() arguments have been reversed. See http://stackoverflow.com/questions/41813665/tensorflow-slim-typeerror-expected-int32-got-list-containing-tensors-of-type I have added a small check to pass the arguments to tf.concat() in the `./net/ops/simple.py` in the correct order depending on the version of TensorFlow that is installed.~
**EDIT:** Whoops, totally messed that up. I was using an older version of TensorFlow and that was causing the issue. No need for any changes (changes have been reverted).

I have tested this with YOLO v2 with both command line interaction as well as with the new direct programmic interaction and everything works fine. Tell me if any changes need to be made.

Thanks!