### PR TITLE
Hint how to run the demo on the GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,17 @@ During training, the script will occasionally save intermediate results into Ten
 
 ### Camera demo
 
+
+For a demo that entirely runs on the CPU:
+
 ```bash
 ./flow --model cfg/yolo-3c.cfg --load bin/yolo-3c.weights --demo camera
+```
+
+For a demo that runs 100% on the GPU:
+
+```bash
+./flow --model cfg/yolo-3c.cfg --load bin/yolo-3c.weights --demo camera --gpu 1.0
 ```
 
 ### Using darkflow from another python application


### PR DESCRIPTION
The readme file had a demo that only runs on the CPU, so the frames were around 1 FPS (i7 first gen) . When the demo is run on the GPU the frames were around 5.74 FPS (on a Titan 1080).