### PR TITLE
Check to see if summary flag exists before enabling TensorBoard features.

### DIFF
--- a/net/build.py
+++ b/net/build.py
@@ -104,9 +104,10 @@ class TFNet(object):
 			cfg['device_count'] = {'GPU': 0}
 
 		if self.FLAGS.train: self.build_train_op()
-
-		self.summary_op = tf.summary.merge_all()
-		self.writer = tf.summary.FileWriter(self.FLAGS.summary + 'train')
+		
+		if self.FLAGS.summary is not None:
+			self.summary_op = tf.summary.merge_all()
+			self.writer = tf.summary.FileWriter(self.FLAGS.summary + 'train')
 		
 		self.sess = tf.Session(config = tf.ConfigProto(**cfg))
 		self.sess.run(tf.global_variables_initializer())
@@ -115,8 +116,9 @@ class TFNet(object):
 		self.saver = tf.train.Saver(tf.global_variables(), 
 			max_to_keep = self.FLAGS.keep)
 		if self.FLAGS.load != 0: self.load_from_ckpt()
-
-		self.writer.add_graph(self.sess.graph)
+		
+		if self.FLAGS.summary is not None:
+			self.writer.add_graph(self.sess.graph)
 
 	def savepb(self):
 		"""


### PR DESCRIPTION
If the "summary" flag doesn't exist, don't use TensorBoard features. Fixes https://github.com/thtrieu/darkflow/issues/157. TensorBoard features can be used in return_predict mode by simply adding the `"summary": "./my-summary-folder"` to the options dictionary.