### PR TITLE
Added support for macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,25 @@ if os.name =='nt' :
         )
     ]
 
+elif os.name =='posix' :
+    ext_modules=[
+        Extension("darkflow.cython_utils.nms",
+            sources=["darkflow/cython_utils/nms.pyx"],
+            libraries=["m"], # Unix-like specific
+            include_dirs=[numpy.get_include()]
+        ),        
+        Extension("darkflow.cython_utils.cy_yolo2_findboxes",
+            sources=["darkflow/cython_utils/cy_yolo2_findboxes.pyx"],
+            libraries=["m"], # Unix-like specific
+            include_dirs=[numpy.get_include()]
+        ),
+        Extension("darkflow.cython_utils.cy_yolo_findboxes",
+            sources=["darkflow/cython_utils/cy_yolo_findboxes.pyx"],
+            libraries=["m"], # Unix-like specific
+            include_dirs=[numpy.get_include()]
+        )
+    ]
+
 else :
     ext_modules=[
         Extension("darkflow.cython_utils.nms",


### PR DESCRIPTION
As the repo has been refactored, with dark flow now a directory and cython_utils in a subdirectory, (Pull Request 176)[https://github.com/thtrieu/darkflow/pull/176] won't merge properly.

This pull request supersedes 176 and enables macOS support - without these changes setup.py will fail because it can't find numpy.