### PR TITLE
Enable loading from .pb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 
 #TensorBoard logs
 summary/
+
+#Built graphs
+graph-cfg/

--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ print(result)
 ## Saving graph and weights to protobuf file
 ./flow --model cfg/yolo.cfg --load bin/yolo.weights --savepb
 ```
-When saving the `.pb` file a `.meta` file will also be generated alongside it. This `.meta` file is a JSON dump of everything in the `meta` dictionary that contains information nessecary for post-processing such as `anchors` and `labels`. This way, everything you need to make predictions from the graph and do post processing is contained in those two files - no need to have the `.cfg` or any labels file tagging along.
+When saving the `.pb` file, a `.meta` file will also be generated alongside it. This `.meta` file is a JSON dump of everything in the `meta` dictionary that contains information nessecary for post-processing such as `anchors` and `labels`. This way, everything you need to make predictions from the graph and do post processing is contained in those two files - no need to have the `.cfg` or any labels file tagging along.
 
 The created `.pb` file can be used to migrate the graph to mobile devices (JAVA / C++ / Objective-C++). The name of input tensor and output tensor are respectively `'input'` and `'output'`. For further usage of this protobuf file, please refer to the official documentation of `Tensorflow` on C++ API [_here_](https://www.tensorflow.org/versions/r0.9/api_docs/cc/index.html). To run it on, say, iOS application, simply add the file to Bundle Resources and update the path to this file inside source code.
 
-Also, darkflow supports loading from a `.pb` and `.meta` file for generating predictions (instead of loading from a `.cfg` and `.ckpt` or `.weights`).
+Also, darkflow supports loading from a `.pb` and `.meta` file for generating predictions (instead of loading from a `.cfg` and checkpoint or `.weights`).
 ```bash
 ## Forward images in test for predictions based on protobuf file
 ./flow --pbLoad graph-cfg/yolo.pb --metaLoad graph-cfg/yolo.meta --test test/

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ print(result)
 ```
 
 
-### Save the built graph to a protobuf file (`.pb`)
+## Save the built graph to a protobuf file (`.pb`)
 
 ```bash
 ## Saving the lastest checkpoint to protobuf file

--- a/README.md
+++ b/README.md
@@ -183,13 +183,24 @@ result = tfnet.return_predict(imgcv)
 print(result)
 ```
 
-### Migrating the graph to mobile devices (JAVA / C++ / Objective-C++)
+### Save the built graph to a protobuf file (`.pb`)
 
 ```bash
 ## Saving the lastest checkpoint to protobuf file
 ./flow --model cfg/yolo-new.cfg --load -1 --savepb
-```
 
-The name of input tensor and output tensor are respectively `'input'` and `'output'`. For further usage of this protobuf file, please refer to the official documentation of `Tensorflow` on C++ API [_here_](https://www.tensorflow.org/versions/r0.9/api_docs/cc/index.html). To run it on, say, iOS application, simply add the file to Bundle Resources and update the path to this file inside source code.
+## Saving graph and weights to protobuf file
+./flow --model cfg/yolo.cfg --load bin/yolo.weights --savepb
+```
+When saving the `.pb` file a `.meta` file will also be generated alongside it. This `.meta` file is a JSON dump of everything in the `meta` dictionary that contains information nessecary for post-processing such as `anchors` and `labels`. This way, everything you need to make predictions from the graph and do post processing is contained in those two files - no need to have the `.cfg` or any labels file tagging along.
+
+The created `.pb` file can be used to migrate the graph to mobile devices (JAVA / C++ / Objective-C++). The name of input tensor and output tensor are respectively `'input'` and `'output'`. For further usage of this protobuf file, please refer to the official documentation of `Tensorflow` on C++ API [_here_](https://www.tensorflow.org/versions/r0.9/api_docs/cc/index.html). To run it on, say, iOS application, simply add the file to Bundle Resources and update the path to this file inside source code.
+
+Also, darkflow supports loading from a `.pb` and `.meta` file for generating predictions (instead of loading from a `.cfg` and `.ckpt` or `.weights`).
+```bash
+## Forward images in test for predictions based on protobuf file
+./flow --pbLoad graph-cfg/yolo.pb --metaLoad graph-cfg/yolo.meta --test test/
+```
+If you'd like to load a `.pb` and `.meta` file when using `return_predict()` you can set the `"pbLoad"` and `"metaLoad"` options in place of the `"model"` and `"load"` options you would normally set.
 
 That's all.

--- a/darkflow/net/build.py
+++ b/darkflow/net/build.py
@@ -74,7 +74,7 @@ class TFNet(object):
 			time.time() - start))
 	
 	def build_from_pb(self):
-		with tf.gfile.GFile("./graph-cfg/yolo.pb", "rb") as f:
+		with tf.gfile.GFile(self.FLAGS.pbLoad, "rb") as f:
 			graph_def = tf.GraphDef()
 			graph_def.ParseFromString(f.read())
 		
@@ -82,7 +82,7 @@ class TFNet(object):
 			graph_def,
 			name=""
 		)
-		with open('./graph-cfg/yolo.meta', 'r') as fp:
+		with open(self.FLAGS.metaLoad, 'r') as fp:
 			self.meta = json.load(fp)
 		self.framework = create_framework(self.meta, self.FLAGS)
 

--- a/darkflow/net/build.py
+++ b/darkflow/net/build.py
@@ -74,7 +74,7 @@ class TFNet(object):
 			time.time() - start))
 	
 	def build_from_pb(self):
-		with tf.gfile.GFile(self.FLAGS.pbLoad, "rb") as f:
+		with tf.gfile.FastGFile(self.FLAGS.pbLoad, "rb") as f:
 			graph_def = tf.GraphDef()
 			graph_def.ParseFromString(f.read())
 		

--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -84,7 +84,7 @@ def return_predict(self, im):
             continue
         boxesInfo.append({
             "label": tmpBox[4],
-            "confidence": tmpBox[6],
+            "confidence": round(tmpBox[6], 2),
             "topleft": {
                 "x": tmpBox[0],
                 "y": tmpBox[2]},

--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -84,7 +84,7 @@ def return_predict(self, im):
             continue
         boxesInfo.append({
             "label": tmpBox[4],
-            "confidence": round(tmpBox[6], 2),
+            "confidence": tmpBox[6],
             "topleft": {
                 "x": tmpBox[0],
                 "y": tmpBox[2]},

--- a/darkflow/net/yolo/__init__.py
+++ b/darkflow/net/yolo/__init__.py
@@ -16,8 +16,8 @@ def constructor(self, meta, FLAGS):
 		r = 2 - (indx % base2) / base
 		g = 2 - (indx % base2) % base
 		return (b * 127, r * 127, g * 127)
-
-	misc.labels(meta, FLAGS)
+	if 'labels' not in meta:
+		misc.labels(meta, FLAGS) #We're not loading from a .pb so we do need to load the labels
 	assert len(meta['labels']) == meta['classes'], (
 		'labels.txt and {} indicate' + ' '
 		'inconsistent class numbers'

--- a/darkflow/net/yolo/__init__.py
+++ b/darkflow/net/yolo/__init__.py
@@ -16,8 +16,8 @@ def constructor(self, meta, FLAGS):
 		r = 2 - (indx % base2) / base
 		g = 2 - (indx % base2) % base
 		return (b * 127, r * 127, g * 127)
-  if 'labels' not in meta:
-    misc.labels(meta, FLAGS) #We're not loading from a .pb so we do need to load the labels
+	if 'labels' not in meta:
+		misc.labels(meta, FLAGS) #We're not loading from a .pb so we do need to load the labels
 	assert len(meta['labels']) == meta['classes'], (
 		'labels.txt and {} indicate' + ' '
 		'inconsistent class numbers'

--- a/darkflow/utils/im_transform.py
+++ b/darkflow/utils/im_transform.py
@@ -1,4 +1,4 @@
-import numpy as np		
+import numpy as np
 import cv2
 
 def imcv2_recolor(im, a = .1):

--- a/flow
+++ b/flow
@@ -29,6 +29,8 @@ flags.DEFINE_string("demo", '', "demo on webcam")
 flags.DEFINE_boolean("profile", False, "profile")
 flags.DEFINE_boolean("json", False, "Outputs bounding box information in json format.")
 flags.DEFINE_boolean("saveVideo", False, "Records video from input video or camera")
+flags.DEFINE_string("pbLoad", "", "path to .pb protobuf file (metaLoad must also be specified)")
+flags.DEFINE_string("metaLoad", "", "path to .meta file generated during --savepb that corresponds to .pb file")
 FLAGS = flags.FLAGS
 
 # make sure all necessary dirs exist


### PR DESCRIPTION
Changes to allow darkflow to load from a `.pb` file. Now when using `--savepb` a `.meta` file is also generated which is a JSON dump of the `.meta` variable (I talked about this here: https://github.com/thtrieu/darkflow/issues/143#issuecomment-292794853)

Two new flags are were created `pbLoad` and `metaLoad` that allow for loading from the `.pb` file and `.meta` file instead of a `.cfg` and `.weights` or checkpoint. Also this eliminates the need to have a labels file tagging along as everything necessary for post-processing is contained in the `.meta` file