### PR TITLE
Annotations won’t be saved to history or re-read to avoid issues discussed in #121. Added Annotations example to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ During training, the script will occasionally save intermediate results into Ten
 
 Example of training on Pascal VOC 2007:
 ```
-#Download the Pascal VOC dataset:
+# Download the Pascal VOC dataset:
 curl -O https://pjreddie.com/media/files/VOCtest_06-Nov-2007.tar
 tar xf VOCtest_06-Nov-2007.tar
 
-#an example of the Pascal VOC annotation format:
+# An example of the Pascal VOC annotation format:
 vim VOCdevkit/VOC2007/Annotations/000001.xml
 
-#train the net on the Pascal dataset:
+# Train the net on the Pascal dataset:
 ./flow --model cfg/yolo-new.cfg --train --dataset "~/VOCdevkit/VOC2007/JPEGImages" --annotation "~/VOCdevkit/VOC2007/Annotations"
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ During training, the script will occasionally save intermediate results into Ten
 ```
 
 Example of training on Pascal VOC 2007:
-```
+```bash
 # Download the Pascal VOC dataset:
 curl -O https://pjreddie.com/media/files/VOCtest_06-Nov-2007.tar
 tar xf VOCtest_06-Nov-2007.tar

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ During training, the script will occasionally save intermediate results into Ten
 ./flow --train --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights
 ```
 
+Example of training on Pascal VOC 2007:
+```
+#Download the Pascal VOC dataset:
+curl -O https://pjreddie.com/media/files/VOCtest_06-Nov-2007.tar
+tar xf VOCtest_06-Nov-2007.tar
+
+#an example of the Pascal VOC annotation format:
+vim VOCdevkit/VOC2007/Annotations/000001.xml
+
+#train the net on the Pascal dataset:
+./flow --model cfg/yolo-new.cfg --train --dataset "~/VOCdevkit/VOC2007/JPEGImages" --annotation "~/VOCdevkit/VOC2007/Annotations"
+```
+
 ## Camera/video file demo
 
 For a demo that entirely runs on the CPU:

--- a/darkflow/net/yolo/data.py
+++ b/darkflow/net/yolo/data.py
@@ -8,47 +8,14 @@ import numpy as np
 import os 
 
 def parse(self, exclusive = False):
-    """
-    Decide whether to parse the annotation or not, 
-    If the parsed file is not already there, parse.
-    """
     meta = self.meta
     ext = '.parsed'
-    history = os.path.join('darkflow', 'net', 'yolo', 'parse-history.txt');
-    if not os.path.isfile(history):
-        file = open(history, 'w')
-        file.close()
-    with open(history, 'r') as f:
-        lines = f.readlines()
-    for line in lines:
-        line = line.strip().split(' ')
-        labels = line[1:]
-        if labels == meta['labels']:
-            if os.path.isfile(line[0]):
-                with open(line[0], 'rb') as f:
-                    return pickle.load(f, encoding = 'latin1')[0]
-
-    # actual parsing
     ann = self.FLAGS.annotation
     if not os.path.isdir(ann):
         msg = 'Annotation directory not found {} .'
         exit('Error: {}'.format(msg.format(ann)))
     print('\n{} parsing {}'.format(meta['model'], ann))
     dumps = pascal_voc_clean_xml(ann, meta['labels'], exclusive)
-
-    save_to = os.path.join('darkflow', 'net', 'yolo', meta['name'])
-    while True:
-        if not os.path.isfile(save_to + ext): break
-        save_to = save_to + '_'
-    save_to += ext
-
-    with open(save_to, 'wb') as f:
-        pickle.dump([dumps], f, protocol = -1)
-    with open(history, 'a') as f:
-        f.write('{} '.format(save_to))
-        f.write(' '.join(meta['labels']))
-        f.write('\n')
-    print('Result saved to {}'.format(save_to))
     return dumps
 
 


### PR DESCRIPTION
When training a new model on a new dataset, it's useful to understand the XML structure required for the files specified in `--annotation`.

To address issue #193 I have added links to the Pascal VOC dataset, an example of how to see the format inside one of the XML files, and a full example of using the `--dataset` and `--annotation` flags.

This is useful for users who are new to YOLO or haven't trained up a net before.