### PR TITLE
Speed up batch post processing performance

### DIFF
--- a/cfg/yolo.cfg
+++ b/cfg/yolo.cfg
@@ -5,8 +5,8 @@ subdivisions=1
 # Training
 # batch=64
 # subdivisions=8
-width=608
-height=608
+width=416
+height=416
 channels=3
 momentum=0.9
 decay=0.0005
@@ -254,5 +254,5 @@ class_scale=1
 coord_scale=1
 
 absolute=1
-thresh = .1
+thresh = .6
 random=1

--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 import tensorflow as tf
 import pickle
+from multiprocessing.pool import ThreadPool
 
 train_stats = (
     'Training statistics: \n'
@@ -135,9 +136,11 @@ def predict(self):
         # Post processing
         self.say('Post processing {} inputs ...'.format(len(inp_feed)))
         start = time.time()
-        for i, prediction in enumerate(out):
-            self.framework.postprocess(prediction,
-                os.path.join(inp_path, this_batch[i]))
+        pool = ThreadPool()
+        pool.map(lambda p: (lambda i, prediction:
+            self.framework.postprocess(
+               prediction, os.path.join(inp_path, this_batch[i])))(*p),
+            enumerate(out))
         stop = time.time(); last = stop - start
 
         # Timing


### PR DESCRIPTION
1. yolo.cfg doesn't work with yolo.weights. The previous code change screwed up the run with yolo.weights of https://drive.google.com/drive/folders/0B1tW_VtY7onidEwyQ2FtQVplWEU

2. Tasks in post processing stage are thread safe. Using ThreadPool to improve the batch post processing performance at least 2x faster with large batch size. (e.g. python flow --imgdir sample_img/ --model cfg/yolo.cfg --load bin/yolo.weights --batch 32)
    
    Note: Please evaluate the performance improvement with large number of images instead of 8 images in sample_img/ by default.