### PR TITLE
Speed up batch post processing performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 
 language: python
 python:

--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 import tensorflow as tf
 import pickle
+from multiprocessing.pool import ThreadPool
 
 train_stats = (
     'Training statistics: \n'
@@ -135,9 +136,11 @@ def predict(self):
         # Post processing
         self.say('Post processing {} inputs ...'.format(len(inp_feed)))
         start = time.time()
-        for i, prediction in enumerate(out):
-            self.framework.postprocess(prediction,
-                os.path.join(inp_path, this_batch[i]))
+        pool = ThreadPool()
+        pool.map(lambda p: (lambda i, prediction:
+            self.framework.postprocess(
+               prediction, os.path.join(inp_path, this_batch[i])))(*p),
+            enumerate(out))
         stop = time.time(); last = stop - start
 
         # Timing


### PR DESCRIPTION
Tasks in post processing stage are thread safe. Using ThreadPool to improve the batch post processing performance at least 2x faster with large batch size. (e.g. python flow --imgdir sample_img/ --model cfg/yolo.cfg --load bin/yolo.weights --batch 32)

Note: Please evaluate the performance improvement with large number of images instead of 8 images in sample_img/ by default.