### PR TITLE
Make import paths relative

### DIFF
--- a/darkflow/cli.py
+++ b/darkflow/cli.py
@@ -1,6 +1,6 @@
 from .defaults import argHandler #Import the default arguments
 import os
-from darkflow.net.build import TFNet
+from .net.build import TFNet
 
 def cliHandler(args):
     FLAGS = argHandler()

--- a/darkflow/cython_utils/cy_yolo2_findboxes.pyx
+++ b/darkflow/cython_utils/cy_yolo2_findboxes.pyx
@@ -3,7 +3,7 @@ cimport numpy as np
 cimport cython
 ctypedef np.float_t DTYPE_t
 from libc.math cimport exp
-from darkflow.utils.box import BoundBox
+from ..utils.box import BoundBox
 from nms cimport NMS
 
 #expit

--- a/darkflow/cython_utils/cy_yolo_findboxes.pyx
+++ b/darkflow/cython_utils/cy_yolo_findboxes.pyx
@@ -3,7 +3,7 @@ cimport numpy as np
 cimport cython
 ctypedef np.float_t DTYPE_t
 from libc.math cimport exp
-from darkflow.utils.box import BoundBox
+from ..utils.box import BoundBox
 from nms cimport NMS
 
 

--- a/darkflow/cython_utils/nms.pyx
+++ b/darkflow/cython_utils/nms.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from libc.math cimport exp
-from darkflow.utils.box import BoundBox
+from ..utils.box import BoundBox
 
 
 

--- a/darkflow/dark/darknet.py
+++ b/darkflow/dark/darknet.py
@@ -1,6 +1,6 @@
-from darkflow.utils.process import cfg_yielder
+from ..utils.process import cfg_yielder
 from .darkop import create_darkop
-from darkflow.utils import loader
+from ..utils import loader
 import warnings
 import time
 import os

--- a/darkflow/dark/layer.py
+++ b/darkflow/dark/layer.py
@@ -1,4 +1,4 @@
-from darkflow.utils import loader
+from ..utils import loader
 import numpy as np
 
 class Layer(object):

--- a/darkflow/net/build.py
+++ b/darkflow/net/build.py
@@ -5,7 +5,7 @@ from . import flow
 from .ops import op_create, identity
 from .ops import HEADER, LINE
 from .framework import create_framework
-from darkflow.dark.darknet import Darknet
+from ..dark.darknet import Darknet
 import json
 import os
 

--- a/darkflow/net/help.py
+++ b/darkflow/net/help.py
@@ -1,7 +1,7 @@
 """
 tfnet secondary (helper) methods
 """
-from darkflow.utils.loader import create_loader
+from ..utils.loader import create_loader
 from time import time as timer
 import tensorflow as tf
 import numpy as np

--- a/darkflow/net/ops/simple.py
+++ b/darkflow/net/ops/simple.py
@@ -104,7 +104,7 @@ class crop(BaseOp):
 class maxpool(BaseOp):
 	def forward(self):
 		self.out = tf.nn.max_pool(
-			self.inp.out, padding = 'VALID',
+			self.inp.out, padding = 'SAME',
 	        ksize = [1] + [self.lay.ksize]*2 + [1], 
 	        strides = [1] + [self.lay.stride]*2 + [1],
 	        name = self.scope

--- a/darkflow/net/yolo/data.py
+++ b/darkflow/net/yolo/data.py
@@ -1,4 +1,4 @@
-from darkflow.utils.pascal_voc_clean_xml import pascal_voc_clean_xml
+from ...utils.pascal_voc_clean_xml import pascal_voc_clean_xml
 from numpy.random import permutation as perm
 from .predict import preprocess
 # from .misc import show

--- a/darkflow/net/yolo/predict.py
+++ b/darkflow/net/yolo/predict.py
@@ -1,9 +1,9 @@
-from darkflow.utils.im_transform import imcv2_recolor, imcv2_affine_trans
-from darkflow.utils.box import BoundBox, box_iou, prob_compare
+from ...utils.im_transform import imcv2_recolor, imcv2_affine_trans
+from ...utils.box import BoundBox, box_iou, prob_compare
 import numpy as np
 import cv2
 import os
-from darkflow.cython_utils.cy_yolo_findboxes import yolo_box_constructor
+from ...cython_utils.cy_yolo_findboxes import yolo_box_constructor
 
 def _fix(obj, dims, scale, offs):
 	for i in range(1, 5):

--- a/darkflow/net/yolov2/data.py
+++ b/darkflow/net/yolov2/data.py
@@ -1,4 +1,4 @@
-from darkflow.utils.pascal_voc_clean_xml import pascal_voc_clean_xml
+from ...utils.pascal_voc_clean_xml import pascal_voc_clean_xml
 from numpy.random import permutation as perm
 from ..yolo.predict import preprocess
 from ..yolo.data import shuffle

--- a/darkflow/net/yolov2/predict.py
+++ b/darkflow/net/yolov2/predict.py
@@ -6,7 +6,7 @@ import os
 #from utils.box import BoundBox, box_iou, prob_compare
 #from utils.box import prob_compare2, box_intersection
 from darkflow.utils.box import BoundBox
-from darkflow.cython_utils.cy_yolo2_findboxes import box_constructor
+from ...cython_utils.cy_yolo2_findboxes import box_constructor
 
 def expit(x):
 	return 1. / (1. + np.exp(-x))

--- a/darkflow/net/yolov2/predict.py
+++ b/darkflow/net/yolov2/predict.py
@@ -5,7 +5,7 @@ import os
 #from scipy.special import expit
 #from utils.box import BoundBox, box_iou, prob_compare
 #from utils.box import prob_compare2, box_intersection
-from darkflow.utils.box import BoundBox
+from ...utils.box import BoundBox
 from ...cython_utils.cy_yolo2_findboxes import box_constructor
 
 def expit(x):

--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 import os
-import darkflow.dark as dark
+import ..dark as dark
 import numpy as np
 from os.path import basename
 

--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 import os
-import ..dark as dark
+from .. import dark
 import numpy as np
 from os.path import basename
 


### PR DESCRIPTION
The majority of import paths were not relative, going directly from `darkflow` (i.e. `from darkflow.net.build import TFNet`) - I think this was causing some issues when people chose to build the Cython extensions in place rather than installing darkflow globally with `pip`. See https://github.com/thtrieu/darkflow/issues/252 and https://github.com/thtrieu/darkflow/issues/168#issuecomment-308652194.

Changing these import paths to relative ones should fix that problem.