### PR TITLE
Use json.dumps for JSON formatting

### DIFF
--- a/darkflow/net/yolo/predict.py
+++ b/darkflow/net/yolo/predict.py
@@ -3,6 +3,7 @@ from ...utils.box import BoundBox, box_iou, prob_compare
 import numpy as np
 import cv2
 import os
+import json
 from ...cython_utils.cy_yolo_findboxes import yolo_box_constructor
 
 def _fix(obj, dims, scale, offs):
@@ -88,7 +89,7 @@ def postprocess(self, net_out, im, save = True):
 	else: imgcv = im
 
 	h, w, _ = imgcv.shape
-	textBuff = "["
+	resultsForJSON = []
 	for b in boxes:
 		boxResults = self.process_box(b, h, w, threshold)
 		if boxResults is None:
@@ -96,12 +97,7 @@ def postprocess(self, net_out, im, save = True):
 		left, right, top, bot, mess, max_indx, confidence = boxResults
 		thick = int((h + w) // 300)
 		if self.FLAGS.json:
-			line = 	('{"label": "%s",'
-					'"confidence": %.2f,'
-					'"topleft": {"x": %d, "y": %d},'
-					'"bottomright": {"x": %d,"y": %d}},\n') % \
-					(mess, confidence, left, top, right, bot)
-			textBuff += line
+			resultsForJSON.append({"label": mess, "confidence": float('%.2f' % confidence), "topleft": {"x": left, "y": top}, "bottomright": {"x": right, "y": bot}})
 			continue
 
 		cv2.rectangle(imgcv,
@@ -115,14 +111,13 @@ def postprocess(self, net_out, im, save = True):
 
 	if not save: return imgcv
 
-	# Removing trailing comma+newline adding json list terminator.
-	textBuff = textBuff[:-2] + "]"
 	outfolder = os.path.join(self.FLAGS.imgdir, 'out')
 	img_name = os.path.join(outfolder, os.path.basename(im))
 	if self.FLAGS.json:
+		textJSON = json.dumps(resultsForJSON)
 		textFile = os.path.splitext(img_name)[0] + ".json"
 		with open(textFile, 'w') as f:
-			f.write(textBuff)
+			f.write(textJSON)
 		return	
 
 	cv2.imwrite(img_name, imgcv)


### PR DESCRIPTION
Change how JSON is generated when using `--json` for both predicting with YOLOv1 and YOLOv2. Instead of using text concatenation, it now uses `json.dumps` for more reliable JSON serialization. Addresses https://github.com/thtrieu/darkflow/issues/300 