### PR TITLE
Fixed yolo-4c cfg to have 4 classes and added new labels flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ person
 pottedplant
 ```
 
-And that's it. `darkflow` will take care of the rest.
+And that's it. `darkflow` will take care of the rest. You can also set darkflow to load from a custom labels file with the `--labels` flag (i.e. `--labels myOtherLabelsFile.txt`). This can be helpful when working with multiple models with different sets of output labels. When this flag is not set, darkflow will load from `labels.txt` by default (unless you are using one of the recognized `.cfg` files designed for the COCO or VOC dataset - then the labels file will be ignored and the COCO or VOC labels will be loaded).
 
 ## Design the net
 

--- a/cfg/tiny-yolo-4c.cfg
+++ b/cfg/tiny-yolo-4c.cfg
@@ -111,13 +111,13 @@ activation=leaky
 size=1
 stride=1
 pad=1
-filters=50
+filters=45
 activation=linear
 
 [region]
 anchors = 1.08,1.19,  3.42,4.41,  6.63,11.38,  9.42,5.11,  16.62,10.52
 bias_match=1
-classes=5
+classes=4
 coords=4
 num=5
 softmax=1

--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -10,6 +10,7 @@ class argHandler(dict):
         self.define('binary', './bin/', 'path to .weights directory')
         self.define('config', './cfg/', 'path to .cfg directory')
         self.define('dataset', '../pascal/VOCdevkit/IMG/', 'path to dataset directory')
+        self.define('labels', 'labels.txt', 'path to labels file')
         self.define('backup', './ckpt/', 'path to backup folder')
         self.define('summary', './summary/', 'path to TensorBoard summaries directory')
         self.define('annotation', '../pascal/VOCdevkit/ANN/', 'path to annotation directory')

--- a/darkflow/net/yolo/misc.py
+++ b/darkflow/net/yolo/misc.py
@@ -26,7 +26,7 @@ def labels(meta, FLAGS):
         print("Model has a VOC model name, loading VOC labels.")
         meta['labels'] = labels20
     else:
-        file = 'labels.txt'
+        file = FLAGS.labels
         if model in coco_models:
             print("Model has a coco model name, loading coco labels.")
             file = os.path.join(FLAGS.config, coco_names)


### PR DESCRIPTION
Minor changes to tiny-yolo-4c.cfg file so that the number of classes output is actually 4. Also allowed users to set the name of their labels file in the event that they run multiple models with different outputs.