### PR TITLE
Allow for false positive training

### DIFF
--- a/darkflow/cli.py
+++ b/darkflow/cli.py
@@ -1,5 +1,6 @@
 from .defaults import argHandler #Import the default arguments
 import os
+import sys
 from .net.build import TFNet
 
 def cliHandler(args):
@@ -19,8 +20,12 @@ def cliHandler(args):
     try: FLAGS.load = int(FLAGS.load)
     except: pass
 
+    if FLAGS.quiet:
+        sys.stdout = os.devnull
+        sys.stderr = os.devnull
+
     tfnet = TFNet(FLAGS)
-    
+
     if FLAGS.demo:
         tfnet.camera()
         exit('Demo stopped, exit.')

--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -35,6 +35,7 @@ class argHandler(dict):
         self.define('saveVideo', False, 'Records video from input video or camera')
         self.define('pbLoad', '', 'path to .pb protobuf file (metaLoad must also be specified)')
         self.define('metaLoad', '', 'path to .meta file generated during --savepb that corresponds to .pb file')
+        self.define('quiet', False, 'suppress output')
 
     def define(self, argName, default, description):
         self[argName] = default

--- a/darkflow/net/yolo/data.py
+++ b/darkflow/net/yolo/data.py
@@ -63,7 +63,8 @@ def _batch(self, chunk):
 
     for obj in allobj:
         probs[obj[5], :] = [0.] * C
-        probs[obj[5], labels.index(obj[0])] = 1.
+        if obj[0] != 'UNDEFINED':
+            probs[obj[5], :, labels.index(obj[0])] = 1.
         proid[obj[5], :] = [1] * C
         coord[obj[5], :, :] = [obj[1:5]] * B
         prear[obj[5],0] = obj[1] - obj[3]**2 * .5 * S # xleft

--- a/darkflow/net/yolo/data.py
+++ b/darkflow/net/yolo/data.py
@@ -60,6 +60,7 @@ def _batch(self, chunk):
     coord = np.zeros([S*S,B,4])
     proid = np.zeros([S*S,C])
     prear = np.zeros([S*S,4])
+
     for obj in allobj:
         probs[obj[5], :] = [0.] * C
         probs[obj[5], labels.index(obj[0])] = 1.

--- a/darkflow/net/yolov2/data.py
+++ b/darkflow/net/yolov2/data.py
@@ -26,6 +26,7 @@ def _batch(self, chunk):
     path = os.path.join(self.FLAGS.dataset, jpg)
     img = self.preprocess(path, allobj)
 
+
     # Calculate regression target
     cellx = 1. * w / W
     celly = 1. * h / H
@@ -51,9 +52,11 @@ def _batch(self, chunk):
     coord = np.zeros([H*W,B,4])
     proid = np.zeros([H*W,B,C])
     prear = np.zeros([H*W,4])
+
     for obj in allobj:
         probs[obj[5], :, :] = [[0.]*C] * B
-        probs[obj[5], :, labels.index(obj[0])] = 1.
+        if obj[0] != 'UNDEFINED':
+            probs[obj[5], :, labels.index(obj[0])] = 1.
         proid[obj[5], :, :] = [[1.]*C] * B
         coord[obj[5], :, :] = [obj[1:5]] * B
         prear[obj[5],0] = obj[1] - obj[3]**2 * .5 * W # xleft

--- a/darkflow/utils/pascal_voc_clean_xml.py
+++ b/darkflow/utils/pascal_voc_clean_xml.py
@@ -45,7 +45,7 @@ def pascal_voc_clean_xml(ANN, pick, exclusive = False):
         for obj in root.iter('object'):
                 current = list()
                 name = obj.find('name').text
-                if name not in pick:
+                if name not in pick and name != "UNDEFINED":
                         continue
 
                 xmlbox = obj.find('bndbox')


### PR DESCRIPTION
If you want to train their models to train against false positives, you must still provide a bounding box and the label "UNDEFINED" in lieu of standard labels such as "bicycle". Doing so will zero out all truth values meaning that your model will be punished for predicting any label.  