### PR TITLE
fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ options = {"model": "cfg/yolo.cfg", "load": "bin/yolo.weights", "threshold": 0.1
 
 tfnet = TFNet(options)
 
-imgcv = cv2.imread("./sample_img/dog.jpg")
+imgcv = cv2.imread("./sample_img/sample_dog.jpg")
 result = tfnet.return_predict(imgcv)
 print(result)
 ```


### PR DESCRIPTION
I fixed README a little.
In example_img directory, sample images are named 'sample_xxx.jpg' but on the readme document, 'sample_img/sample_dog.jpg' was written like 'sample_img/dog.jpg'.
I fixed the part of this document.