### PR TITLE
Update to im_transform.py

### DIFF
--- a/darkflow/utils/im_transform.py
+++ b/darkflow/utils/im_transform.py
@@ -11,7 +11,8 @@ def imcv2_recolor(im, a = .1):
 	im = im * (1 + t * a)
 	mx = 255. * (1 + a)
 	up = np.random.uniform() * 2 - 1
-	im = np.power(im/mx, 1. + up * .5)
+# 	im = np.power(im/mx, 1. + up * .5)
+	im = cv2.pow(im/mx, 1. + up * .5)
 	return np.array(im * 255., np.uint8)
 
 def imcv2_affine_trans(im):


### PR DESCRIPTION
Using openCV's power function is 6x faster than Numpy's here.

OpenCV: cv2.pow(im/mx, 1. + up * .5)
10 loops, best of 3: 28.7 ms per loop

Numpy: np.power(im/mx, 1. + up * .5)
10 loops, best of 3: 185 ms per loop

np.testing.assert_allclose(np.power(im/mx, 1. + up * .5), cv2.pow(im/mx, 1. + up * .5))