### PR TITLE
yolo-tiny to tiny-yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ flow --h
 First, let's take a closer look at one of a very useful option `--load`
 
 ```bash
-# 1. Load yolo-tiny.weights
-flow --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights
+# 1. Load tiny-yolo.weights
+flow --model cfg/tiny-yolo.cfg --load bin/tiny-yolo.weights
 
 # 2. To completely initialize a model, leave the --load option
 flow --model cfg/yolo-new.cfg
 
 # 3. It is useful to reuse the first identical layers of tiny for `yolo-new`
-flow --model cfg/yolo-new.cfg --load bin/yolo-tiny.weights
+flow --model cfg/yolo-new.cfg --load bin/tiny-yolo.weights
 # this will print out which layers are reused, which are initialized
 ```
 
@@ -103,12 +103,12 @@ All input images from default folder `sample_img/` are flowed through the net an
 
 ```bash
 # Forward all images in sample_img/ using tiny yolo and 100% GPU usage
-flow --imgdir sample_img/ --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights --gpu 1.0
+flow --imgdir sample_img/ --model cfg/tiny-yolo.cfg --load bin/tiny-yolo.weights --gpu 1.0
 ```
 json output can be generated with descriptions of the pixel location of each bounding box and the pixel location. Each prediction is stored in the `sample_img/out` folder by default. An example json array is shown below.
 ```bash
 # Forward all images in sample_img/ using tiny yolo and JSON output.
-flow --imgdir sample_img/ --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights --json
+flow --imgdir sample_img/ --model cfg/tiny-yolo.cfg --load bin/tiny-yolo.weights --json
 ```
 JSON output:
 ```json
@@ -127,7 +127,7 @@ Training is simple as you only have to add option `--train`. Training set and an
 
 ```bash
 # Initialize yolo-new from yolo-tiny, then train the net on 100% GPU:
-flow --model cfg/yolo-new.cfg --load bin/yolo-tiny.weights --train --gpu 1.0
+flow --model cfg/yolo-new.cfg --load bin/tiny-yolo.weights --train --gpu 1.0
 
 # Completely initialize yolo-new and train it with ADAM optimizer
 flow --model cfg/yolo-new.cfg --train --trainer adam
@@ -143,7 +143,7 @@ flow --train --model cfg/yolo-new.cfg --load -1
 flow --model cfg/yolo-new.cfg --load 1500
 
 # Fine tuning yolo-tiny from the original one
-flow --train --model cfg/yolo-tiny.cfg --load bin/yolo-tiny.weights
+flow --train --model cfg/tiny-yolo.cfg --load bin/tiny-yolo.weights
 ```
 
 Example of training on Pascal VOC 2007:


### PR DESCRIPTION
no such file as cfg/yolo-tiny.cfg.
Changed all related occurrences