### PR TITLE
Using ThreadPool to speed up batch pre-processing

### DIFF
--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -115,15 +115,10 @@ def predict(self):
         to_idx = min(from_idx + batch, len(all_inps))
 
         # collect images input in the batch
-        inp_feed = list(); new_all = list()
         this_batch = all_inps[from_idx:to_idx]
-        for inp in this_batch:
-            new_all += [inp]
-            this_inp = os.path.join(inp_path, inp)
-            this_inp = self.framework.preprocess(this_inp)
-            expanded = np.expand_dims(this_inp, 0)
-            inp_feed.append(expanded)
-        this_batch = new_all
+        inp_feed = pool.map(lambda inp: (
+            np.expand_dims(self.framework.preprocess(
+                os.path.join(inp_path, inp)), 0)), this_batch)
 
         # Feed to the net
         feed_dict = {self.inp : np.concatenate(inp_feed, 0)}    


### PR DESCRIPTION
Tasks in pre-processing stage are thread safe. Using ThreadPool to improve the batch pre-processing performance at least 2x faster with large batch size. (e.g. python flow --imgdir sample_img/ --model cfg/yolo.cfg --load bin/yolo.weights --batch 32)

Note: Please evaluate the performance improvement with large number of images instead of 8 images in sample_img/ by default.