### PR TITLE
Allowing remote URLs for demo mode

### DIFF
--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -35,6 +35,7 @@ class argHandler(dict):
         self.define('saveVideo', False, 'Records video from input video or camera')
         self.define('pbLoad', '', 'path to .pb protobuf file (metaLoad must also be specified)')
         self.define('metaLoad', '', 'path to .meta file generated during --savepb that corresponds to .pb file')
+        self.define('notificationURL', '', 'http(s) url for reporting detections in JSON format')
 
     def define(self, argName, default, description):
         self[argName] = default

--- a/darkflow/net/help.py
+++ b/darkflow/net/help.py
@@ -71,9 +71,9 @@ def camera(self):
     
     if file == 'camera':
         file = 0
-    else:
-        assert os.path.isfile(file), \
-        'file {} does not exist'.format(file)
+#    else:
+#        assert os.path.isfile(file), \
+#        'file {} does not exist'.format(file)
         
     camera = cv2.VideoCapture(file)
     


### PR DESCRIPTION
Allows using http(s) urls e.g. for predicting on mjpeg streams.