### PR TITLE
Introduce notification URL for prediction results.

### DIFF
--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -35,6 +35,7 @@ class argHandler(dict):
         self.define('saveVideo', False, 'Records video from input video or camera')
         self.define('pbLoad', '', 'path to .pb protobuf file (metaLoad must also be specified)')
         self.define('metaLoad', '', 'path to .meta file generated during --savepb that corresponds to .pb file')
+        self.define('notificationURL', '', 'http(s) url for reporting detections in JSON format')
 
     def define(self, argName, default, description):
         self[argName] = default

--- a/darkflow/net/yolov2/predict.py
+++ b/darkflow/net/yolov2/predict.py
@@ -8,6 +8,7 @@ import json
 #from utils.box import prob_compare2, box_intersection
 from ...utils.box import BoundBox
 from ...cython_utils.cy_yolo2_findboxes import box_constructor
+import requests
 
 def expit(x):
 	return 1. / (1. + np.exp(-x))
@@ -47,15 +48,23 @@ def postprocess(self, net_out, im, save = True):
 			continue
 		left, right, top, bot, mess, max_indx, confidence = boxResults
 		thick = int((h + w) // 300)
-		if self.FLAGS.json:
-			resultsForJSON.append({"label": mess, "confidence": float('%.2f' % confidence), "topleft": {"x": left, "y": top}, "bottomright": {"x": right, "y": bot}})
-			continue
+		resultsForJSON.append({"label": mess, "confidence": float('%.2f' % confidence), "width": w, "height": h, "topleft": {"x": left, "y": top}, "bottomright": {"x": right, "y": bot}})
 
 		cv2.rectangle(imgcv,
 			(left, top), (right, bot),
 			colors[max_indx], thick)
 		cv2.putText(imgcv, mess, (left, top - 12),
 			0, 1e-3 * h, colors[max_indx],thick//3)
+
+	if self.FLAGS.notificationURL != '':
+
+		url = self.FLAGS.notificationURL
+
+		try:
+			resp = requests.post(url, json=resultsForJSON )
+
+		except:
+			print("Failed sending detection result.");
 
 	if not save: return imgcv
 


### PR DESCRIPTION
Replaces pull request #506  due to mixed up changeset.

This patch posts JSON requests to a remote server (URL specified via command line). The payload contains the internal detection results (detected class/label, location in image, confidence level and additionally the original image size). The original image size is required for calculating the relative position of detected objects inside the image.