### PR TITLE
Allow remote URLs in demo mode (makes prediction possible on remote video streams)

### DIFF
--- a/darkflow/net/help.py
+++ b/darkflow/net/help.py
@@ -71,9 +71,6 @@ def camera(self):
     
     if file == 'camera':
         file = 0
-    else:
-        assert os.path.isfile(file), \
-        'file {} does not exist'.format(file)
         
     camera = cv2.VideoCapture(file)
     


### PR DESCRIPTION
Replaces pull request #506 .

Allows prediction on remote streams e.g. mjpeg streams (predicting on single images captured from camera requires to start the model for each frame which is far from being fast).

This way one can capture and detect objects on remotely visible webcams (tested and got easily 20fps).