### PR TITLE
Some modifications to TensorBoard behaviour

### DIFF
--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -12,7 +12,7 @@ class argHandler(dict):
         self.define('dataset', '../pascal/VOCdevkit/IMG/', 'path to dataset directory')
         self.define('labels', 'labels.txt', 'path to labels file')
         self.define('backup', './ckpt/', 'path to backup folder')
-        self.define('summary', './summary/', 'path to TensorBoard summaries directory')
+        self.define('summary', '', 'path to TensorBoard summaries directory')
         self.define('annotation', '../pascal/VOCdevkit/ANN/', 'path to annotation directory')
         self.define('threshold', -0.1, 'detection threshold')
         self.define('model', '', 'configuration of choice')

--- a/darkflow/net/build.py
+++ b/darkflow/net/build.py
@@ -138,7 +138,7 @@ class TFNet(object):
 
 		if self.FLAGS.train: self.build_train_op()
 		
-		if self.FLAGS.summary is not None:
+		if self.FLAGS.summary:
 			self.summary_op = tf.summary.merge_all()
 			self.writer = tf.summary.FileWriter(self.FLAGS.summary + 'train')
 		
@@ -150,7 +150,7 @@ class TFNet(object):
 			max_to_keep = self.FLAGS.keep)
 		if self.FLAGS.load != 0: self.load_from_ckpt()
 		
-		if self.FLAGS.summary is not None:
+		if self.FLAGS.summary:
 			self.writer.add_graph(self.sess.graph)
 
 	def savepb(self):

--- a/darkflow/net/flow.py
+++ b/darkflow/net/flow.py
@@ -48,7 +48,11 @@ def train(self):
         feed_dict[self.inp] = x_batch
         feed_dict.update(self.feed)
 
-        fetches = [self.train_op, loss_op, self.summary_op] 
+        fetches = [self.train_op, loss_op]
+
+        if self.FLAGS.summary:
+            fetches.append(self.summary_op)
+
         fetched = self.sess.run(fetches, feed_dict)
         loss = fetched[1]
 
@@ -56,7 +60,8 @@ def train(self):
         loss_mva = .9 * loss_mva + .1 * loss
         step_now = self.FLAGS.load + i + 1
 
-        self.writer.add_summary(fetched[2], step_now)
+        if self.FLAGS.summary:
+            self.writer.add_summary(fetched[2], step_now)
 
         form = 'step {} - loss {} - moving ave loss {}'
         self.say(form.format(step_now, loss, loss_mva))


### PR DESCRIPTION
1. Turn off TensorBoard logs by default. They can be enabled by setting the `--summary` flag with the desired output folder for TensorBoard logs.

2. Fix check to see if the `summary` flag is checked. Any "falsy" value should disable it.