### PR TITLE
Only check existance of summary directory if flag is set

### DIFF
--- a/darkflow/cli.py
+++ b/darkflow/cli.py
@@ -12,8 +12,12 @@ def cliHandler(args):
         for d in dirs:
             this = os.path.abspath(os.path.join(os.path.curdir, d))
             if not os.path.exists(this): os.makedirs(this)
-    _get_dir([FLAGS.imgdir, FLAGS.binary, FLAGS.backup, 
-             os.path.join(FLAGS.imgdir,'out'), FLAGS.summary])
+    
+    requiredDirectories = [FLAGS.imgdir, FLAGS.binary, FLAGS.backup, os.path.join(FLAGS.imgdir,'out')]
+    if FLAGS.summary:
+        requiredDirectories.append(FLAGS.summary)
+
+    _get_dir(requiredDirectories)
 
     # fix FLAGS.load to appropriate type
     try: FLAGS.load = int(FLAGS.load)


### PR DESCRIPTION
If the `--summary` flag is not set, there is no need to ensure that the `FLAGS.summary` directory exists.