### PR TITLE
Show error message when an image is corrupted

### DIFF
--- a/darkflow/net/yolo/data.py
+++ b/darkflow/net/yolo/data.py
@@ -110,7 +110,13 @@ def shuffle(self):
 
             for j in range(b*batch, b*batch+batch):
                 train_instance = data[shuffle_idx[j]]
-                inp, new_feed = self._batch(train_instance)
+                try:
+                    inp, new_feed = self._batch(train_instance)
+                except ZeroDivisionError:
+                    print("This image's width or height are zeros: ", train_instance[0])
+                    print('train_instance:', train_instance)
+                    print('Please remove or fix it then try again.')
+                    raise
 
                 if inp is None: continue
                 x_batch += [np.expand_dims(inp, 0)]


### PR DESCRIPTION
From issue #558 people will not know what is the bug about.
With this update, we will output which image is corrupted so people know which image to remove.
It does not fix darkflow's image reading mechanics but it's showing which image darkflow cannot read.
And that's helpful for me.