### PR TITLE
Correct offset in the weights reader (tiny YOLO v2 Coco)

### DIFF
--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -114,11 +114,15 @@ class weights_walker(object):
             return
         else: 
             self.size = os.path.getsize(path)# save the path
-            major, minor, revision, seen = np.memmap(path,
+            major, minor, revision = np.memmap(path,
                 shape = (), mode = 'r', offset = 0,
-                dtype = '({})i4,'.format(4))
+                dtype = '({})i4,'.format(3))
             self.transpose = major > 1000 or minor > 1000
-            self.offset = 16
+            if ((major*10 + minor) >= 2 and major < 1000 and minor < 1000):
+                import ctypes
+                self.offset = 12 + ctypes.sizeof(ctypes.c_size_t)
+            else:
+                self.offset = 16
 
     def walk(self, size):
         if self.eof: return None

--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -154,3 +154,4 @@ def model_name(file_path):
         return '-'.join(file_name[:-1])
     if ext == 'weights':
         return file_name
+    

--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -154,4 +154,3 @@ def model_name(file_path):
         return '-'.join(file_name[:-1])
     if ext == 'weights':
         return file_name
-    


### PR DESCRIPTION
When trying to load the tiny YOLO v2 configuration and  weights (trained on COCO) from the pjreddie website I got an `AssertionError: expect 44948596 bytes, found 44948600`. (Using the tiny-yolo.cfg from this repository returned an `Over-read tiny-yolo.weights` error)
In the parser in the darknet github, the `seen` metadata is saved as size_t type rather than int which seemed to mess with the initial offset.