### PR TITLE
import tensorflow as tf for line 16

### DIFF
--- a/darkflow/net/vanilla/train.py
+++ b/darkflow/net/vanilla/train.py
@@ -1,3 +1,5 @@
+import tensorflow as tf
+
 _LOSS_TYPE = ['sse','l2', 'smooth',
 			  'sparse', 'l1', 'softmax',
 			  'svm', 'fisher']


### PR DESCRIPTION
Discovered via #658    Resolves many but not all of the 16 undefined names...

flake8 testing of https://github.com/thtrieu/darkflow on Python 3.6.3
```
$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
./darkflow/net/vanilla/train.py:14:11: F821 undefined name 'tf'
	_truth = tf.placeholders(out_dtype, out_shape)
          ^
./darkflow/net/vanilla/train.py:22:10: F821 undefined name 'tf'
		loss = tf.nn.l2_loss(diff)
         ^
./darkflow/net/vanilla/train.py:25:11: F821 undefined name 'tf'
		small = tf.cast(diff < 1, tf.float32)
          ^
./darkflow/net/vanilla/train.py:25:29: F821 undefined name 'tf'
		small = tf.cast(diff < 1, tf.float32)
                            ^
./darkflow/net/vanilla/train.py:27:13: F821 undefined name 'tf'
		l1_loss = tf.nn.l1_loss(tf.multiply(diff, large))
            ^
./darkflow/net/vanilla/train.py:27:27: F821 undefined name 'tf'
		l1_loss = tf.nn.l1_loss(tf.multiply(diff, large))
                          ^
./darkflow/net/vanilla/train.py:28:13: F821 undefined name 'tf'
		l2_loss = tf.nn.l2_loss(tf.multiply(diff, small))
            ^
./darkflow/net/vanilla/train.py:28:27: F821 undefined name 'tf'
		l2_loss = tf.nn.l2_loss(tf.multiply(diff, small))
                          ^
./darkflow/net/vanilla/train.py:35:10: F821 undefined name 'tf'
		loss = tf.nn.softmax_cross_entropy_with_logits(logits, y)
         ^
./darkflow/net/vanilla/train.py:35:50: F821 undefined name 'logits'
		loss = tf.nn.softmax_cross_entropy_with_logits(logits, y)
                                                 ^
./darkflow/net/vanilla/train.py:35:58: F821 undefined name 'y'
		loss = tf.nn.softmax_cross_entropy_with_logits(logits, y)
                                                         ^
./darkflow/net/vanilla/train.py:36:10: F821 undefined name 'tf'
		loss = tf.reduce_mean(loss)
         ^
./darkflow/net/vanilla/train.py:42:13: F821 undefined name 'tf'
		self.nu = tf.Variable(tf.ones([train_size, num_classes]))            ^
./darkflow/net/vanilla/train.py:42:25: F821 undefined name 'tf'
		self.nu = tf.Variable(tf.ones([train_size, num_classes]))                        ^
./darkflow/net/vanilla/train.py:42:34: F821 undefined name 'train_size'
		self.nu = tf.Variable(tf.ones([train_size, num_classes]))                                 ^
./darkflow/net/vanilla/train.py:42:46: F821 undefined name 'num_classes'
		self.nu = tf.Variable(tf.ones([train_size, num_classes]))                                             ^
16    F821 undefined name 'tf'
```