### PR TITLE
make it work with darknet weights

### DIFF
--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -118,7 +118,7 @@ class weights_walker(object):
                 shape = (), mode = 'r', offset = 0,
                 dtype = '({})i4,'.format(4))
             self.transpose = major > 1000 or minor > 1000
-            self.offset = 16
+            self.offset = 20
 
     def walk(self, size):
         if self.eof: return None


### PR DESCRIPTION
The weight file format in darknet must have been changed. This tiny change fixes it. So you can use weight files generated by darknet.