### PR TITLE
Added performance flags for better inference performance on Xeon

### DIFF
--- a/darkflow/defaults.py
+++ b/darkflow/defaults.py
@@ -1,11 +1,15 @@
+from platform_util import platform
+
 class argHandler(dict):
     #A super duper fancy custom made CLI argument handler!!
     __getattr__ = dict.get
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
     _descriptions = {'help, --h, -h': 'show this super helpful message and exit'}
-    
+
     def setDefaults(self):
+        p = platform()
+
         self.define('imgdir', './sample_img/', 'path to testing directory with images')
         self.define('binary', './bin/', 'path to .weights directory')
         self.define('config', './cfg/', 'path to .cfg directory')
@@ -35,6 +39,12 @@ class argHandler(dict):
         self.define('saveVideo', False, 'Records video from input video or camera')
         self.define('pbLoad', '', 'path to .pb protobuf file (metaLoad must also be specified)')
         self.define('metaLoad', '', 'path to .meta file generated during --savepb that corresponds to .pb file')
+        self.define('inter_op', 2, 'Maximum number of ops to run in parallel');
+        self.define('intra_op', p.num_cores_per_socket() * p.num_cpu_sockets(), 'Number of threads to use for each CPU op')
+        self.define('KMP_BLOCKTIME', 0, 'Time (in ms) a thread should wait after a parallel region before sleeping')
+        self.define('KMP_SETTINGS', 0, 'Enables printing of OpenMP environment variables')
+        self.define('KMP_AFFINITY', 'granularity=fine,compact,1,0', 'Enables binding of threads to physical processing units')
+        self.define('timeline_enabled', False, 'Run 20 batches and then dump the timeline in JSON format');
 
     def define(self, argName, default, description):
         self[argName] = default

--- a/darkflow/net/build.py
+++ b/darkflow/net/build.py
@@ -136,6 +136,24 @@ class TFNet(object):
 			self.say('Running entirely on CPU')
 			cfg['device_count'] = {'GPU': 0}
 
+                # Set CPU-specific parallelism flags
+                cfg['inter_op_parallelism_threads'] = self.FLAGS.inter_op
+                cfg['intra_op_parallelism_threads'] = self.FLAGS.intra_op
+                os.environ["KMP_BLOCKTIME"] = str(self.FLAGS.KMP_BLOCKTIME)
+                os.environ["KMP_SETTINGS"] = str(self.FLAGS.KMP_SETTINGS)
+                os.environ["KMP_AFFINITY"] = str(self.FLAGS.KMP_AFFINITY)
+                os.environ["OMP_NUM_THREADS"]= str(self.FLAGS.intra_op)
+
+                print '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+                print 'CPU parallelism settings - tweak defaults for better performance:'
+                print 'See https://www.tensorflow.org/performance/performance_guide#tensorflow_with_intel_mkl_dnn for details'
+                print 'inter_op', self.FLAGS.inter_op
+                print 'intra_op', self.FLAGS.intra_op
+                print 'KMP_BLOCKTIME', self.FLAGS.KMP_BLOCKTIME
+                print 'KMP_AFFINITY', self.FLAGS.KMP_AFFINITY
+                print 'KMP_SETTINGS', self.FLAGS.KMP_SETTINGS
+                print '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+
 		if self.FLAGS.train: self.build_train_op()
 		
 		if self.FLAGS.summary:

--- a/darkflow/platform_util.py
+++ b/darkflow/platform_util.py
@@ -1,0 +1,78 @@
+import os
+import subprocess
+from sys import exit
+
+'''This module implements a platform utility that exposes functions that detect platform information.'''
+
+NUMA_NODES_STR_       = "NUMA node(s)"
+CPU_SOCKETS_STR_      = "Socket(s)"
+CORES_PER_SOCKET_STR_ = "Core(s) per socket"
+THREADS_PER_CORE_STR_ = "Thread(s) per core"
+LOGICAL_CPUS_STR_     = "CPU(s)"
+
+class platform:
+  cpu_sockets_      = 0
+  cores_per_socket_ = 0
+  threads_per_core_ = 0
+  logical_cpus_     = 0
+  numa_nodes_       = 0
+
+  def num_cpu_sockets(self):
+    return self.cpu_sockets_
+
+  def num_cores_per_socket(self):
+    return self.cores_per_socket_
+
+  def num_threads_per_core(self):
+    return self.threads_per_core_
+
+  def num_logical_cpus(self):
+    return self.logical_cpus_
+
+  def num_numa_nodes(self):
+    return self.numa_nodes_
+
+  def __init__(self):
+    #check to see if the lscpu command is present
+    lscpu_path = ''
+    try:
+      process = subprocess.Popen(["which", "lscpu"],
+                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      stdout,stderr = process.communicate()
+      if stderr:
+        print "Error: {}".format(stderr)
+        exit(1)
+      else:
+        lscpu_path = stdout.strip()
+    except:
+      print "Error!"
+
+    #get the lscpu output
+    cpu_info = ''
+    if lscpu_path:
+      try:
+        process = subprocess.Popen(lscpu_path,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+        stdout,stderr = process.communicate()
+        cpu_info = stdout.split('\n')
+      except:
+        print "Error!@"
+
+    #parse it
+    for line in cpu_info:
+#      NUMA_NODES_STR_       = "NUMA node(s)"
+      if line.find(NUMA_NODES_STR_) == 0:
+        self.numa_nodes_ = int(line.split(":")[1].strip())
+#      CPU_SOCKETS_STR_      = "Socket(s)"
+      elif line.find(CPU_SOCKETS_STR_) == 0:
+        self.cpu_sockets_ = int(line.split(":")[1].strip())
+#      CORES_PER_SOCKET_STR_ = "Core(s) per socket"
+      elif line.find(CORES_PER_SOCKET_STR_) == 0:
+        self.cores_per_socket_ = int(line.split(":")[1].strip())
+#      THREADS_PER_CORE_STR_ = "Thread(s) per core"
+      elif line.find(THREADS_PER_CORE_STR_) == 0:
+        self.threads_per_core_ = int(line.split(":")[1].strip())
+#      LOGICAL_CPUS_STR_     = "CPU(s)"
+      elif line.find(LOGICAL_CPUS_STR_) == 0:
+        self.logical_cpus_ = int(line.split(":")[1].strip())


### PR DESCRIPTION
I'm a part of the TensorFlow optimization team at Intel and we're working on improving performance of YoloV2/darkflow on Xeon. As a first step, I'm adding the ability to measure and tweak performance. We will also contribute changes to TensorFlow and MKL-DNN to speed up YoloV2/DarkFlow.

- Added flags for getting better performance during inference when running on TensorFlow built with MKL-DNN
- Added a script to generate reasonable defaults for these flags depending on the system being used
- Added ability to generate timeline to find performance bottlenecks

With the right settings, inference performance on a 28 core Xeon Scalable Processor goes up by more than 60%