### PR TITLE
Fix loading problem for some of darknet's models, i.e. `assert end_point <= self.size`

### DIFF
--- a/darkflow/utils/loader.py
+++ b/darkflow/utils/loader.py
@@ -114,11 +114,26 @@ class weights_walker(object):
             return
         else: 
             self.size = os.path.getsize(path)# save the path
-            major, minor, revision, seen = np.memmap(path,
+            major, minor, revision = np.memmap(path,
                 shape = (), mode = 'r', offset = 0,
-                dtype = '({})i4,'.format(4))
+                dtype = '({})i4,'.format(3))
+            
+            self.offset = 12
+            
+            if major * 10 + minor >= 2:
+                # Reading version >= 2
+                seen = np.memmap(path,
+                    shape = (), mode = 'r', offset = 12,
+                    dtype = '({})i8,'.format(1))
+                self.offset += 8
+            else:
+                # Reading version >= 2
+                seen = np.memmap(path,
+                    shape = (), mode = 'r', offset = 12,
+                    dtype = '({})i4,'.format(1))
+                self.offset += 4
+
             self.transpose = major > 1000 or minor > 1000
-            self.offset = 16
 
     def walk(self, size):
         if self.eof: return None


### PR DESCRIPTION
This fixed the problem reported in several issues including #644, #586, #576, #432, #325, #223, #187, #153, #141, #24.

When the number of steps is lower than 32 bits, it will be saved in a 32-bit integer, not a 64-bit integer.  