### PR TITLE
Fix ground truth xml paths gathering method

### DIFF
--- a/darkflow/utils/pascal_voc_clean_xml.py
+++ b/darkflow/utils/pascal_voc_clean_xml.py
@@ -19,7 +19,7 @@ def pascal_voc_clean_xml(ANN, pick, exclusive = False):
     cur_dir = os.getcwd()
     os.chdir(ANN)
     annotations = os.listdir('.')
-    annotations = glob.glob(str(annotations)+'*.xml')
+    annotations = glob.glob('*.xml')
     size = len(annotations)
 
     for i, file in enumerate(annotations):


### PR DESCRIPTION
There is an ssue when files had a dash (-) in name. E.g. issue #753
Now it just look for files with xml extension.