### PR TITLE
Generalize number of output parameters

### DIFF
--- a/darkflow/net/yolov2/data.py
+++ b/darkflow/net/yolov2/data.py
@@ -53,15 +53,15 @@ def _batch(self, chunk):
     proid = np.zeros([H*W,B,C])
     prear = np.zeros([H*W,bbox_params])
     for obj in allobj:
-        probs[obj[5], :, :] = [[0.]*C] * B
-        probs[obj[5], :, labels.index(obj[0])] = 1.
-        proid[obj[5], :, :] = [[1.]*C] * B
-        coord[obj[5], :, :] = [obj[1:5]] * B
-        prear[obj[5],0] = obj[1] - obj[3]**2 * .5 * W # xleft
-        prear[obj[5],1] = obj[2] - obj[4]**2 * .5 * H # yup
-        prear[obj[5],2] = obj[1] + obj[3]**2 * .5 * W # xright
-        prear[obj[5],3] = obj[2] + obj[4]**2 * .5 * H # ybot
-        confs[obj[5], :] = [1.] * B
+        probs[obj[-1], :, :] = [[0.]*C] * B
+        probs[obj[-1], :, labels.index(obj[0])] = 1.
+        proid[obj[-1], :, :] = [[1.]*C] * B
+        coord[obj[-1], :, :] = [obj[1:5]] * B
+        prear[obj[-1],0] = obj[1] - obj[3]**2 * .5 * W # xleft
+        prear[obj[-1],1] = obj[2] - obj[4]**2 * .5 * H # ytop
+        prear[obj[-1],2] = obj[1] + obj[3]**2 * .5 * W # xright
+        prear[obj[-1],3] = obj[2] + obj[4]**2 * .5 * H # ybot
+        confs[obj[-1], :] = [1.] * B
 
     # Finalise the placeholders' values
     upleft   = np.expand_dims(prear[:,0:2], 1)

--- a/darkflow/net/yolov2/data.py
+++ b/darkflow/net/yolov2/data.py
@@ -19,6 +19,7 @@ def _batch(self, chunk):
     H, W, _ = meta['out_size']
     C, B = meta['classes'], meta['num']
     anchors = meta['anchors']
+    bbox_params = meta['coords']
 
     # preprocess
     jpg = chunk[0]; w, h, allobj_ = chunk[1]
@@ -48,9 +49,9 @@ def _batch(self, chunk):
     # Calculate placeholders' values
     probs = np.zeros([H*W,B,C])
     confs = np.zeros([H*W,B])
-    coord = np.zeros([H*W,B,4])
+    coord = np.zeros([H*W,B,bbox_params])
     proid = np.zeros([H*W,B,C])
-    prear = np.zeros([H*W,4])
+    prear = np.zeros([H*W,bbox_params])
     for obj in allobj:
         probs[obj[5], :, :] = [[0.]*C] * B
         probs[obj[5], :, labels.index(obj[0])] = 1.

--- a/darkflow/net/yolov2/train.py
+++ b/darkflow/net/yolov2/train.py
@@ -62,7 +62,7 @@ def loss(self, net_out):
     adjusted_coords_wh = tf.sqrt(tf.exp(coords[:,:,:,2:4]) * np.reshape(anchors, [1, 1, B, 2]) / np.reshape([W, H], [1, 1, 1, 2]))
     coords = tf.concat([adjusted_coords_xy, adjusted_coords_wh], 3)
 
-    adjusted_c = expit_tensor(net_out_reshape[:, :, :, :, bbox_params])  # Changed this: confidence score is last parameter
+    adjusted_c = expit_tensor(net_out_reshape[:, :, :, :, bbox_params])  # Confidence score is last parameter
     adjusted_c = tf.reshape(adjusted_c, [-1, H*W, B, 1])
 
     adjusted_prob = tf.nn.softmax(net_out_reshape[:, :, :, :, (bbox_params+1):])


### PR DESCRIPTION
This PR removes the hardcoded number of output parameters and generalizes it based on the `coords` value in the `.cfg` files. Usually `coords` is set to 4 (for x, y, w, h), but this PR changes this to allow for more values. 