### PR TITLE
space_to_depth

### DIFF
--- a/darkflow/net/ops/convolution.py
+++ b/darkflow/net/ops/convolution.py
@@ -24,8 +24,8 @@ class reorg(BaseOp):
     def forward(self):
         inp = self.inp.out
         s = self.lay.stride
-        self.out = tf.extract_image_patches(
-            inp, [1,s,s,1], [1,s,s,1], [1,1,1,1], 'VALID')
+        self.out = tf.space_to_depth(
+            inp, s, 'VALID')
 
     def speak(self):
         args = [self.lay.stride] * 2


### PR DESCRIPTION
ONNX doesn't support extract_image_patches, but does support space_to_depth. For the case that darkflow uses extract_iamge_patches they are equivalent.