### PR TITLE
Update setup.py to Python 3.4+ Compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools.extension import Extension
 from Cython.Build import cythonize
 import numpy
 import os
-import imp
+from importlib.machinery import SourceFileLoader
 
-VERSION = imp.load_source('version', os.path.join('.', 'darkflow', 'version.py'))
+VERSION = SourceFileLoader('version', './darkflow/version.py').load_module()
 VERSION = VERSION.__version__
 
 if os.name =='nt' :


### PR DESCRIPTION
According to the Python documentation, the imp library is "deprecated since version 3.4: The imp package is pending deprecation in favor of importlib." That's why I replace the imp call with importlib to make it compatible with Python higher than 3.4.

I'm proposing this, because I went into issue building the darkflow with Python 3.5.1 or higher. Hope this would help others who encountered the same issue. =]

Further info about imp, refer to the Python Documentation below:
https://docs.python.org/3/library/imp.html